### PR TITLE
feat: Implement add stock functionality and endpoint

### DIFF
--- a/back-nest/src/products/dto/add-stock.dto.ts
+++ b/back-nest/src/products/dto/add-stock.dto.ts
@@ -1,0 +1,24 @@
+import { IsInt, IsPositive, IsOptional, IsString, Min } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class AddStockDto {
+  @ApiProperty({ description: "Quantity to add", example: 10 })
+  @IsInt()
+  @IsPositive()
+  quantity: number;
+
+  @ApiProperty({ description: "Additional notes", example: "Stock replenishment", required: false })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+
+  @ApiProperty({ description: "Supplier name", example: "Default Supplier", required: false })
+  @IsString()
+  @IsOptional()
+  supplier: string = "Default Supplier";
+
+  @ApiProperty({ description: "Unit price", example: 0, required: false })
+  @Min(0)
+  @IsOptional()
+  unitPrice: number = 0;
+}

--- a/back-nest/src/products/products.controller.spec.ts
+++ b/back-nest/src/products/products.controller.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductsController } from './products.controller';
+import { ProductsService } from './products.service';
+import { StockInService } from '../stock-in/stock-in.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AddStockDto } from './dto/add-stock.dto';
+import { CreateStockInDto } from '../stock-in/dto/create-stock-in.dto';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('ProductsController', () => {
+  let controller: ProductsController;
+  let stockInService: StockInService;
+
+  const mockProductsService = {
+    // Add mock methods for ProductsService if needed for other tests
+  };
+
+  const mockStockInService = {
+    create: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProductsController],
+      providers: [
+        { provide: ProductsService, useValue: mockProductsService },
+        { provide: StockInService, useValue: mockStockInService },
+        PrismaService, // Add PrismaService if it's a direct or indirect dependency for other controller methods
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<ProductsController>(ProductsController);
+    stockInService = module.get<StockInService>(StockInService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('addStockToProduct', () => {
+    const productId = 'test-product-id';
+    const addStockDto: AddStockDto = {
+      quantity: 10,
+      notes: 'Test stock addition',
+      supplier: 'Test Supplier',
+      unitPrice: 5,
+    };
+
+    const expectedStockInResponse = {
+      id: 'stock-in-id',
+      reference: 'IN-test-p-1234567890',
+      date: new Date(),
+      supplier: 'Test Supplier',
+      notes: 'Test stock addition',
+      productId: productId,
+      quantity: 10,
+      unitPrice: 5,
+      product: {} as any, // Mock product object if needed
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('should successfully add stock to a product', async () => {
+      mockStockInService.create.mockResolvedValue(expectedStockInResponse);
+
+      const result = await controller.addStockToProduct(productId, addStockDto);
+
+      expect(stockInService.create).toHaveBeenCalledTimes(1);
+      const createStockInDtoArg = mockStockInService.create.mock.calls[0][0] as CreateStockInDto;
+
+      expect(createStockInDtoArg.productId).toBe(productId);
+      expect(createStockInDtoArg.quantity).toBe(addStockDto.quantity);
+      expect(createStockInDtoArg.notes).toBe(addStockDto.notes);
+      expect(createStockInDtoArg.supplier).toBe(addStockDto.supplier);
+      expect(createStockInDtoArg.unitPrice).toBe(addStockDto.unitPrice);
+      expect(createStockInDtoArg.reference).toEqual(expect.any(String));
+      // Check if the reference starts with the expected prefix, if the format is strict
+      expect(createStockInDtoArg.reference.startsWith(`IN-${productId.substring(0,5)}`)).toBe(true);
+      // Check date is a valid ISO string, as it's converted in the controller
+      expect(createStockInDtoArg.date).toEqual(expect.any(String));
+      const parsedDate = new Date(createStockInDtoArg.date);
+      expect(parsedDate).toEqual(expect.any(Date));
+      expect(isNaN(parsedDate.getTime())).toBe(false);
+
+
+      expect(result).toEqual(expectedStockInResponse);
+    });
+
+    it('should use default supplier and unitPrice if not provided in DTO', async () => {
+      const addStockDtoDefaults: AddStockDto = {
+        quantity: 5,
+      };
+      const expectedResponseDefaults = {
+        ...expectedStockInResponse,
+        quantity: 5,
+        supplier: "Default Supplier", // Default from AddStockDto
+        unitPrice: 0, // Default from AddStockDto
+        notes: undefined,
+      };
+      mockStockInService.create.mockResolvedValue(expectedResponseDefaults);
+
+      await controller.addStockToProduct(productId, addStockDtoDefaults);
+
+      expect(stockInService.create).toHaveBeenCalledTimes(1);
+      const createStockInDtoArg = mockStockInService.create.mock.calls[0][0] as CreateStockInDto;
+
+      expect(createStockInDtoArg.supplier).toBe("Default Supplier");
+      expect(createStockInDtoArg.unitPrice).toBe(0);
+      expect(createStockInDtoArg.notes).toBeUndefined();
+    });
+
+
+    it('should throw an error if StockInService.create fails', async () => {
+      const serviceError = new Error('Service error');
+      mockStockInService.create.mockRejectedValue(serviceError);
+
+      await expect(controller.addStockToProduct(productId, addStockDto)).rejects.toThrow('Service error');
+      expect(stockInService.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/back-nest/src/products/products.module.ts
+++ b/back-nest/src/products/products.module.ts
@@ -2,9 +2,10 @@ import { Module } from "@nestjs/common"
 import { ProductsService } from "./products.service"
 import { ProductsController } from "./products.controller"
 import { PrismaModule } from "../prisma/prisma.module"
+import { StockInModule } from "../stock-in/stock-in.module" // Added
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, StockInModule], // Added StockInModule
   controllers: [ProductsController],
   providers: [ProductsService],
   exports: [ProductsService],

--- a/front-next/components/products/add-stock-modal.tsx
+++ b/front-next/components/products/add-stock-modal.tsx
@@ -63,9 +63,8 @@ export function AddStockModal({ open, onOpenChange, onStockAdded, productId, pro
     setIsSubmitting(true)
 
     try {
-      // ในระบบจริง คุณอาจจะต้องสร้าง API endpoint สำหรับการเพิ่ม stock โดยเฉพาะ
-      // แต่ในตัวอย่างนี้ เราจะใช้ API endpoint ที่มีอยู่แล้ว
-      const response = await fetchWithAuth(`/api/products/${productId}/stock`, {
+      // Call the NestJS backend directly
+      const response = await fetchWithAuth(`http://localhost:3001/api/products/${productId}/stock`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -91,19 +90,6 @@ export function AddStockModal({ open, onOpenChange, onStockAdded, productId, pro
       }
     } catch (error) {
       console.error("Error adding stock:", error)
-
-      // Fallback if API doesn't exist yet
-      if (error instanceof Error && error.message.includes("404")) {
-        toast({
-          title: "Stock Added (Demo)",
-          description: `Added ${data.quantity} units to ${productName} (This is a demo, API not implemented yet)`,
-        })
-        onOpenChange(false)
-        if (onStockAdded) {
-          onStockAdded()
-        }
-        return
-      }
 
       // Check if error is related to authentication
       if (error instanceof Error && error.message.includes("Authentication")) {


### PR DESCRIPTION
This commit introduces the backend endpoint and integrates the frontend for the "Add Stock" feature in the product management page.

Key changes:
- Added `AddStockDto` in `back-nest/src/products/dto/` to handle incoming data for adding stock, including quantity, notes, and optional supplier/unitPrice with default values.
- Implemented a new method `addStockToProduct` in `ProductsController` (`back-nest/src/products/products.controller.ts`) mapped to `POST /api/products/:id/stock`. This method uses `StockInService` to create a stock-in record and update product quantity.
- Ensured `StockInService` is correctly injected into `ProductsController` by importing `StockInModule` into `ProductsModule`.
- Updated the frontend `AddStockModal` (`front-next/components/products/add-stock-modal.tsx`) to call the new backend endpoint directly (`http://localhost:3001/api/products/:id/stock`) and removed the previous fallback/demo logic.
- Added comprehensive unit tests for the `addStockToProduct` method in `ProductsController`, covering successful cases, default value handling, and error scenarios.

The new endpoint requires authentication and updates the product quantity while also recording the stock-in transaction, ensuring data integrity.